### PR TITLE
Unbeast output fix

### DIFF
--- a/src/Writer/Formats/Unbeast.hs
+++ b/src/Writer/Formats/Unbeast.hs
@@ -75,10 +75,10 @@ writeUnbeast c s = do
       ++ "\n" ++ "  </GlobalOutputs>"
       ++ (if null as then "" 
           else "\n" ++ "  <Assumptions>" ++
-               concatMap (\x -> "<LTL>" ++ printFormula 4 x ++ "</LTL>") as ++
+               concatMap (\x -> "\n    <LTL>\n" ++ printFormula 6 x ++ "    </LTL>\n") as ++
                "  </Assumptions>")
       ++ "\n" ++ "  <Specification>"
-      ++ concatMap (\x -> "<LTL>" ++ printFormula 4 x ++ "</LTL>") vs
+      ++ concatMap (\x -> "\n    <LTL>\n" ++ printFormula 6 x ++ "    </LTL>\n") vs
       ++ "  </Specification>"
       ++ "\n" ++ "</SynthesisProblem>"
       ++ "\n"

--- a/src/Writer/Formats/Unbeast.hs
+++ b/src/Writer/Formats/Unbeast.hs
@@ -78,7 +78,7 @@ writeUnbeast c s = do
                concatMap (\x -> "<LTL>" ++ printFormula 4 x ++ "</LTL>") as ++
                "  </Assumptions>")
       ++ "\n" ++ "  <Specification>"
-      ++ concatMap (printFormula 4) vs
+      ++ concatMap (\x -> "<LTL>" ++ printFormula 4 x ++ "</LTL>") vs
       ++ "  </Specification>"
       ++ "\n" ++ "</SynthesisProblem>"
       ++ "\n"

--- a/src/Writer/Formats/Unbeast.hs
+++ b/src/Writer/Formats/Unbeast.hs
@@ -75,7 +75,7 @@ writeUnbeast c s = do
       ++ "\n" ++ "  </GlobalOutputs>"
       ++ (if null as then "" 
           else "\n" ++ "  <Assumptions>" ++
-               concatMap (printFormula 4) as ++
+               concatMap (\x -> "<LTL>" ++ printFormula 4 x ++ "</LTL>") as ++
                "  </Assumptions>")
       ++ "\n" ++ "  <Specification>"
       ++ concatMap (printFormula 4) vs


### PR DESCRIPTION
The Unbeast output did not seem to work. The tool requires all assumptions and guarantees to be encapsulated in <LTL> tags, which has been added.
