### PR TITLE
Add SMV as a format target option

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -556,6 +556,18 @@ checkConfiguration cfg
         "the weak until operator.\n" ++
         "Remove at least one of these constaints."                
 
+  | negNormalForm cfg && noRelease cfg && noGlobally cfg &&
+    outputFormat cfg == SMV =
+
+      argsError $
+        "The given combination of transformations " ++
+        "(negation normal form, no release operators, and " ++
+        "no globally operators)" ++
+        "is impossible to satisfy when outputting to the " ++
+        "SMV format, since it does not support " ++ 
+        "the weak until operator.\n" ++
+        "Remove at least one of these constaints."                
+
   | negNormalForm cfg && noGlobally cfg && outputFormat cfg == PSL =
 
       argsError $

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -233,6 +233,7 @@ prHelp = do
     , "      * slugs                     : structured Slugs format [GR(1) only]"
     , "      * slugsin                   : SlugsIn format [GR(1) only]"
     , "      * psl                       : PSL Syntax"
+    , "      * smv                       : SMV file format"
     , "" 
     , "  -m, --mode                      : Output mode. Possible values are"
     , ""

--- a/src/Writer.hs
+++ b/src/Writer.hs
@@ -64,6 +64,7 @@ import qualified Writer.Formats.SlugsIn as SlugsIn
 import qualified Writer.Formats.Basic as Basic
 import qualified Writer.Formats.Full as Full
 import qualified Writer.Formats.Psl as Psl
+import qualified Writer.Formats.Smv as Smv
 
 -----------------------------------------------------------------------------
 
@@ -104,6 +105,7 @@ writeSpecification c s = do
     SLUGS   -> Slugs.writeFormat c s     
     SLUGSIN -> SlugsIn.writeFormat c s
     PSL     -> Psl.writeFormat c s 
+    SMV     -> Smv.writeFormat c s 
   
 -----------------------------------------------------------------------------
 

--- a/src/Writer/Formats.hs
+++ b/src/Writer/Formats.hs
@@ -38,6 +38,7 @@ data WriteFormat =
   | SLUGSIN
   | FULL  
   | PSL
+  | SMV
   deriving (Eq)
 
 -----------------------------------------------------------------------------
@@ -56,6 +57,7 @@ instance Show WriteFormat where
     SLUGSIN -> "SlugsIn"
     FULL    -> "Full"
     PSL     -> "Psl"
+    SMV     -> "SMV"
 
 -----------------------------------------------------------------------------
 
@@ -77,6 +79,7 @@ parseFormat s = case s of
   "slugsin" -> return SLUGSIN
   "basic"   -> return BASIC
   "full"    -> return FULL
+  "smv"     -> return SMV
   x         -> argsError ("Unknown format: " ++ x)
 
 -----------------------------------------------------------------------------

--- a/src/Writer/Formats/Smv.hs
+++ b/src/Writer/Formats/Smv.hs
@@ -1,0 +1,81 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Writer.Formats.SMV
+-- License     :  MIT (see the LICENSE file)
+-- Maintainer  :  Felix Klein (klein@react.uni-saarland.de)
+-- 
+-- Transforms a specification to SMV format.
+-- 
+-----------------------------------------------------------------------------
+
+module Writer.Formats.Smv where
+
+-----------------------------------------------------------------------------
+
+import Config
+import Simplify
+
+import Data.Error
+import Data.Specification
+
+import Writer.Eval
+import Writer.Data
+import Writer.Utils
+
+-----------------------------------------------------------------------------
+
+-- | Promela operator configuration.
+
+opConfig
+  :: OperatorConfig
+
+opConfig = OperatorConfig
+  { tTrue      = "TRUE"
+  , fFalse     = "FALSE"
+  , opNot      = UnaryOp  "!"   1
+  , opAnd      = BinaryOp "&"  3 AssocLeft
+  , opOr       = BinaryOp "|"  3 AssocLeft
+  , opImplies  = BinaryOp "->"  3 AssocLeft
+  , opEquiv    = BinaryOp "<->" 3 AssocLeft
+  , opNext     = UnaryOp  "X"   1 
+  , opFinally  = UnaryOp  "F"  1 
+  , opGlobally = UnaryOp  "G"  1  
+  , opUntil    = BinaryOp "U"   2 AssocLeft 
+  , opRelease  = BinaryOp "V"   2 AssocLeft 
+  , opWeak     = BinaryOpUnsupported
+  }
+
+-----------------------------------------------------------------------------
+
+-- | Promela LTL writer.
+
+writeFormat
+  :: Configuration -> Specification -> Either Error String
+
+writeFormat config spec = do
+  (es,ss,rs,as,is,gs) <- eval config spec
+  formula <- merge es ss rs as is gs
+  simplified_formula <- simplify (adjust config opConfig) formula
+    
+  
+  (input_signals, output_signals) <- evalSignals config spec
+  let 
+    signals = (input_signals ++ output_signals)
+  
+  return $ main (printFormula opConfig (outputMode config) simplified_formula) signals
+  
+  where 
+    main formula signals =
+        "MODULE main\n"
+        ++ "\tVAR\n"
+        ++ (printSignals signals)
+        ++ "\tLTLSPEC " ++ formula ++ "\n"
+
+    printSignals signals = case signals of
+      []               -> ""
+      (signal:signals) -> "\t\t" ++ signal ++ " : boolean;\n" ++ (printSignals signals)
+
+-----------------------------------------------------------------------------
+
+
+         

--- a/src/Writer/Formats/Smv.hs
+++ b/src/Writer/Formats/Smv.hs
@@ -1,10 +1,12 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Writer.Formats.SMV
+-- Module      :  Writer.Formats.Smv
 -- License     :  MIT (see the LICENSE file)
 -- Maintainer  :  Felix Klein (klein@react.uni-saarland.de)
 -- 
 -- Transforms a specification to SMV format.
+-- See http://nusmv.fbk.eu/NuSMV/userman/v21/nusmv_3.html#SEC31 for more
+-- information about the SMV LTL specification.
 -- 
 -----------------------------------------------------------------------------
 
@@ -24,7 +26,7 @@ import Writer.Utils
 
 -----------------------------------------------------------------------------
 
--- | Promela operator configuration.
+-- | SMV LTL operator configuration.
 
 opConfig
   :: OperatorConfig
@@ -47,7 +49,7 @@ opConfig = OperatorConfig
 
 -----------------------------------------------------------------------------
 
--- | Promela LTL writer.
+-- | SMV LTL writer.
 
 writeFormat
   :: Configuration -> Specification -> Either Error String


### PR DESCRIPTION
This enables the usage of the tool `smvtoaig` from the AIGER toolset to generate a monitoring automaton from a TLSF specification (which can be further used to model check solutions from TLSF synthesizer).
