### PR TITLE
Negation normal form rewrites equivalence to top-level and

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -356,7 +356,7 @@ simplify c f =
         | nw || nd                          -> simplify' $ Or [Until x y, Globally x]
         | otherwise                        -> Weak (simplify' x) $ simplify' y
       Equiv x y
-        | nnf                              -> simplify' $ Or [ And [ x, y ], And [ Not x, Not y ] ]
+        | nnf                              -> simplify' $ And [ Or [ Not x, y ], Or [ x, Not y ] ]
         | otherwise                        -> Equiv (simplify' x) (simplify' y)
       Implies x y
         | nnf                              -> simplify' $ Or [ Not x, y ]


### PR DESCRIPTION
I propose that the negation normal form rewrite rules rewrite equivalences `x ↔ y` as `(¬x ∨ y)∧(x ∨ ¬y)` instead of the previous `(x ∧ y)∨(¬x ∧ ¬y)`. They are semantically equivalent, but the former allows the changes proposed in #30 and #31 to split more specifications with top-level equivalences, if combined with the `-nnf` option.