### PR TITLE
fix bug in simplify

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -184,7 +184,7 @@ simplify c f =
         | otherwise                        -> Next $ simplify' $ And xs
       Next (Or xs)
         | hn                               -> simplify' $ Or $ map Next xs
-        | otherwise                        -> Next $ simplify' $ And xs
+        | otherwise                        -> Next $ simplify' $ Or xs
       Globally (Next x)
         | ss || ln || hg                     -> simplify' $ Next $ Globally x
         | ng || nd                          -> simplify' $ Release FFalse $ Next x


### PR DESCRIPTION
With 8a847c995db1601893d365b22d9769643e8c26ad a bug was introduced s.t. [narylatch_2.txt](https://github.com/reactive-systems/syfco/files/4746947/narylatch_2.txt)
is rewritten to 
`{"semantics": "mealy", "inputs": ["upd", "in_0", "in_1"], "outputs": ["out_0", "out_1"], "assumptions": [], "guarantees": ["(G ((upd) -> (((((((in_0) <-> (out_0)) && ((in_0) -> (X (((out_0) U (upd)) && (G (out_0)))))) && ((! (in_0)) -> (X (((! (out_0)) U (upd)) && (G (! (out_0))))))) && ((in_1) <-> (out_1))) && ((in_1) -> (X (((out_1) U (upd)) && (G (out_1)))))) && ((! (in_1)) -> (X (((! (out_1)) U (upd)) && (G (! (out_1)))))))))"] }`
which is incorrect.
