### PR TITLE
add Finite as a builtin, and fix a typo

### DIFF
--- a/misc/tlsf-mode.el
+++ b/misc/tlsf-mode.el
@@ -29,8 +29,8 @@
 
 (defvar tlsf-builtin
   '("G" "F" "X" "U" "R" "W" "AND" "OR"    
-    "Mealy" "Moore" "Strict" "NOT"  "IN"
-    "EQIUV" "IMPLIES" "true" "false" "MIN" "MAX"
+    "Mealy" "Moore" "Strict" "Finite" "NOT" "IN"
+    "EQUIV" "IMPLIES" "true" "false" "MIN" "MAX"
     "ELEM" "SIZE" "SIZEOF" "MUL" "DIV" "MOD"
     "PLUS" "MINUS" "SETMINUS" "CAP" "CUP" "EQ"
     "NEQ" "LE" "LEQ" "GE" "GEQ" "SUM" "PROD"


### PR DESCRIPTION
When I opened a TLSF file with Finite semantics in emacs, I noticed that Finite was not highlighted.
And while patching this in, I noticed the EQUIV was misspelled.

Note that TSLF v1.2 not only adds the Finite semantics, but also the X[!] (strong next) operator.  This will not work well with `tlsf-pretty-symbols` since that transforms `X[!]` into `◯[¬]`.  I don't care about pretty symbols, so I'm not attempting to fix that, just mentioning it *en passant*.