### PR TITLE
fix incorrect simplification rule

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -188,7 +188,7 @@ simplify c f =
       Finally (Next x)
         | ss || ln || hf                     -> simplify' $ Next $ Finally x
         | nf || nd                          -> simplify' $ Until TTrue $ Next x
-        | otherwise                        -> Finally $ simplify' $ StrongNext x
+        | otherwise                        -> Finally $ simplify' $ Next x
       Next (Finally x)
         | (hn && not hf) || (lf && not ln && not ss) -> simplify' $ Finally $ Next x
         | otherwise                        -> Next $ simplify' $ Finally x


### PR DESCRIPTION
Commit 41c3198 mistakenly corrupted the Simplify function to turn Simplify(F(X(e)) into F(Simplify(X[!]e)), introducing a strong Next where there was none.

This reverts that part of the change and fixes #53.